### PR TITLE
fix quote in OpenLiberty-Blog.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -466,7 +466,7 @@ blog:
       Heiko Rupp of Red Hat has started a German tutorial series on MicroProfile on his YouTube channel.
 
   - url: 'https://openliberty.io/blog/2018/08/16/whats-next-microprofile-jakartaee.html'
-    title: 'What's next for MicroProfile and Jakarta EE?'
+    title: 'What''s next for MicroProfile and Jakarta EE?'
     date: '2018-08-16'
     author: 'Kevin Sutter'
     tags:


### PR DESCRIPTION
little fix on the OpenLiberty post view.

The same one was presenting error in the simple quote in the word "what's" with this generating error and not displaying the posts