### PR TITLE
Escape single quote in last blog entry

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -466,7 +466,7 @@ blog:
       Heiko Rupp of Red Hat has started a German tutorial series on MicroProfile on his YouTube channel.
 
   - url: 'https://openliberty.io/blog/2018/08/16/whats-next-microprofile-jakartaee.html'
-    title: 'What's next for MicroProfile and Jakarta EE?'
+    title: 'What''s next for MicroProfile and Jakarta EE?'
     date: '2018-08-16'
     author: 'Kevin Sutter'
     tags:


### PR DESCRIPTION
The blog is currently not rendering on the site as this yaml file cannot be parsed. The apostrophe in `what's next for MicroProfile and Jakarta EE?` was being treated as a string terminator, and needs escaping. For reference, escaping a single quote in YAML is `''` as opposed to `\'`.